### PR TITLE
Wallet/redirect from login

### DIFF
--- a/apps/wallet/src/app/auth/auth-routing.module.ts
+++ b/apps/wallet/src/app/auth/auth-routing.module.ts
@@ -4,6 +4,7 @@ import { AuthComponent } from './auth.component';
 import { CreateAccountComponent } from './create-account/create-account.component';
 import { ImportAccountComponent } from './import-account/import-account.component';
 import { LoginComponent } from './login/login.component';
+import { LoginGuard } from './login.guard';
 
 const routes: Routes = [
   {
@@ -20,7 +21,8 @@ const routes: Routes = [
       },
       {
         path: 'login',
-        component: LoginComponent
+        component: LoginComponent,
+        canActivate: [LoginGuard]
       },
       {
         path: '',

--- a/apps/wallet/src/app/auth/create-account/create-account.component.html
+++ b/apps/wallet/src/app/auth/create-account/create-account.component.html
@@ -3,17 +3,26 @@
 <form [formGroup]="newAccountForm" fxLayout="column" (submit)="saveAccountAndLogin()">
   <mat-form-field>
     <mat-label>Wallet address</mat-label>
-    <input matInput type="text" formControlName="address">
+    <input matInput type="text" formControlName="address" />
   </mat-form-field>
   <mat-form-field>
     <mat-label>Account name</mat-label>
-    <input matInput type="text" formControlName="accountName">
+    <input matInput type="text" formControlName="accountName" />
   </mat-form-field>
-  <wallet-password-form-field formControlName="password" [confirmation]="true"></wallet-password-form-field>
+  <wallet-password-form-field
+    formControlName="password"
+    [confirmation]="true"
+  ></wallet-password-form-field>
   <div fxLayout="row" class="actions" fxLayout.xs="column-reverse" fxLayoutGap="8px">
-    <a routerLink="../login" mat-button color="primary">Login</a>
+    <a
+      [disabled]="loginDisabled$ | async"
+      class="login-link"
+      routerLink="../login"
+      mat-button
+      color="primary"
+      >Login</a
+    >
     <a routerLink="../import" mat-button color="primary">Import account</a>
-    <span fxFlex="1 1 auto"></span>
-    <button mat-flat-button color="primary">Create</button>
+    <span fxFlex="1 1 auto"></span> <button mat-flat-button color="primary">Create</button>
   </div>
 </form>

--- a/apps/wallet/src/app/auth/create-account/create-account.component.spec.ts
+++ b/apps/wallet/src/app/auth/create-account/create-account.component.spec.ts
@@ -1,17 +1,17 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { ImportAccountComponent } from './import-account.component';
 import { Router } from '@angular/router';
 import { By } from '@angular/platform-browser';
 import { SharedModule } from '../../shared';
 import { PasswordFormFieldModule } from '../components/password-form-field/password-form-field.module';
 import { LocalAccountsService, AuthService } from '../../core';
-import { LtoService } from '@lto/core';
+import { LtoService, LTO_NETWORK_BYTE } from '@lto/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
+import { CreateAccountComponent } from './create-account.component';
 
-describe('auth/ImportAccountComponent', () => {
-  let component: ImportAccountComponent;
-  let fixture: ComponentFixture<ImportAccountComponent>;
+describe('auth/CreateAccountComponent', () => {
+  let component: CreateAccountComponent;
+  let fixture: ComponentFixture<CreateAccountComponent>;
   let localAccounts: LocalAccountsService;
   let authService: AuthService;
   let ltoService: LtoService;
@@ -19,7 +19,7 @@ describe('auth/ImportAccountComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SharedModule, PasswordFormFieldModule, NoopAnimationsModule],
-      declarations: [ImportAccountComponent],
+      declarations: [CreateAccountComponent],
       providers: [
         {
           provide: LocalAccountsService,
@@ -32,12 +32,13 @@ describe('auth/ImportAccountComponent', () => {
           useValue: {} as Partial<AuthService>
         },
         {
-          provide: LtoService,
-          useValue: {} as Partial<LtoService>
-        },
-        {
           provide: Router,
           useValue: {}
+        },
+        LtoService.provider,
+        {
+          provide: LTO_NETWORK_BYTE,
+          useValue: 'T'
         }
       ]
     }).compileComponents();
@@ -46,7 +47,7 @@ describe('auth/ImportAccountComponent', () => {
     authService = TestBed.get(AuthService);
     ltoService = TestBed.get(LtoService);
 
-    fixture = TestBed.createComponent(ImportAccountComponent);
+    fixture = TestBed.createComponent(CreateAccountComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/apps/wallet/src/app/auth/create-account/create-account.component.ts
+++ b/apps/wallet/src/app/auth/create-account/create-account.component.ts
@@ -5,6 +5,8 @@ import { Router } from '@angular/router';
 import { MatSnackBar } from '@angular/material';
 import { Account } from 'lto-api';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'wallet-create-account',
@@ -13,12 +15,12 @@ import { FormGroup, FormControl, Validators } from '@angular/forms';
 })
 export class CreateAccountComponent implements OnInit {
   ltoAccount!: Account;
-
+  loginDisabled$!: Observable<boolean>;
   newAccountForm!: FormGroup;
 
   constructor(
     private _ltoApi: LtoService,
-    private _localUserAccountsServce: LocalAccountsService,
+    private _localAccountsService: LocalAccountsService,
     private _authService: AuthService,
     private _router: Router,
     private _snackbar: MatSnackBar
@@ -32,6 +34,10 @@ export class CreateAccountComponent implements OnInit {
       accountName: new FormControl('', [Validators.required]),
       password: new FormControl('', [Validators.required])
     });
+
+    this.loginDisabled$ = this._localAccountsService.availableAccounts$.pipe(
+      map(accounts => accounts.length === 0)
+    );
   }
 
   saveAccountAndLogin() {
@@ -40,7 +46,7 @@ export class CreateAccountComponent implements OnInit {
     }
     try {
       const { accountName, password } = this.newAccountForm.value;
-      const userAccount = this._localUserAccountsServce.createLocalAccount(
+      const userAccount = this._localAccountsService.createLocalAccount(
         this.ltoAccount,
         accountName,
         password

--- a/apps/wallet/src/app/auth/import-account/import-account.component.html
+++ b/apps/wallet/src/app/auth/import-account/import-account.component.html
@@ -12,8 +12,8 @@
   </mat-form-field>
   <wallet-password-form-field formControlName="password" [confirmation]="true"></wallet-password-form-field>
   <div fxLayout="row" class="actions" fxLayout.xs="column-reverse" fxLayoutGap="8px">
-    <a routerLink="../login" mat-button color="primary">Login</a>
-    <a routerLink="../import" mat-button color="primary">Create account</a>
+    <a routerLink="../login" class="login-link" mat-button color="primary">Login</a>
+    <a routerLink="../create" mat-button color="primary">Create account</a>
     <span fxFlex="1 1 auto"></span>
     <button mat-flat-button color="primary">Import</button>
   </div>

--- a/apps/wallet/src/app/auth/import-account/import-account.component.html
+++ b/apps/wallet/src/app/auth/import-account/import-account.component.html
@@ -8,13 +8,22 @@
   <p>After import your account will be saved locally</p>
   <mat-form-field>
     <mat-label>Account name</mat-label>
-    <input matInput type="text" formControlName="accountName">
+    <input matInput type="text" formControlName="accountName" />
   </mat-form-field>
-  <wallet-password-form-field formControlName="password" [confirmation]="true"></wallet-password-form-field>
+  <wallet-password-form-field
+    formControlName="password"
+    [confirmation]="true"
+  ></wallet-password-form-field>
   <div fxLayout="row" class="actions" fxLayout.xs="column-reverse" fxLayoutGap="8px">
-    <a routerLink="../login" class="login-link" mat-button color="primary">Login</a>
+    <a
+      [disabled]="loginDisabled$ | async"
+      routerLink="../login"
+      class="login-link"
+      mat-button
+      color="primary"
+      >Login</a
+    >
     <a routerLink="../create" mat-button color="primary">Create account</a>
-    <span fxFlex="1 1 auto"></span>
-    <button mat-flat-button color="primary">Import</button>
+    <span fxFlex="1 1 auto"></span> <button mat-flat-button color="primary">Import</button>
   </div>
 </form>

--- a/apps/wallet/src/app/auth/import-account/import-account.component.spec.ts
+++ b/apps/wallet/src/app/auth/import-account/import-account.component.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed, async, ComponentFixture } from '@angular/core/testing';
+import { ImportAccountComponent } from './import-account.component';
+import { By } from '@angular/platform-browser';
+import { SharedModule } from '../../shared';
+import { PasswordFormFieldModule } from '../components/password-form-field/password-form-field.module';
+import { LocalAccountsService, AuthService } from '../../core';
+
+fdescribe('auth/ImportAccountComponent', () => {
+  let component: ImportAccountComponent;
+  let fixture: ComponentFixture<ImportAccountComponent>;
+  let localAccounts: LocalAccountsService;
+  let authService: AuthService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [SharedModule, PasswordFormFieldModule],
+      declarations: [ImportAccountComponent],
+      providers: [
+        {
+          provide: LocalAccountsService,
+          useValue: {} as Partial<LocalAccountsService>
+        },
+        {
+          provide: AuthService,
+          useValue: {} as Partial<AuthService>
+        }
+      ]
+    }).compileComponents();
+
+    localAccounts = TestBed.get(LocalAccountsService);
+    authService = TestBed.get(AuthService);
+
+    fixture = TestBed.createComponent(ImportAccountComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should disable Login button if no local accounts presented', () => {
+    const loginLink = fixture.debugElement.query(By.css('.login-link'));
+  });
+});

--- a/apps/wallet/src/app/auth/import-account/import-account.component.spec.ts
+++ b/apps/wallet/src/app/auth/import-account/import-account.component.spec.ts
@@ -1,34 +1,50 @@
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { ImportAccountComponent } from './import-account.component';
+import { Router } from '@angular/router';
 import { By } from '@angular/platform-browser';
 import { SharedModule } from '../../shared';
 import { PasswordFormFieldModule } from '../components/password-form-field/password-form-field.module';
 import { LocalAccountsService, AuthService } from '../../core';
+import { LtoService } from '@lto/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
 
-fdescribe('auth/ImportAccountComponent', () => {
+describe('auth/ImportAccountComponent', () => {
   let component: ImportAccountComponent;
   let fixture: ComponentFixture<ImportAccountComponent>;
   let localAccounts: LocalAccountsService;
   let authService: AuthService;
+  let ltoService: LtoService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SharedModule, PasswordFormFieldModule],
+      imports: [SharedModule, PasswordFormFieldModule, NoopAnimationsModule],
       declarations: [ImportAccountComponent],
       providers: [
         {
           provide: LocalAccountsService,
-          useValue: {} as Partial<LocalAccountsService>
+          useValue: {
+            availableAccounts$: of([])
+          } as Partial<LocalAccountsService>
         },
         {
           provide: AuthService,
           useValue: {} as Partial<AuthService>
+        },
+        {
+          provide: LtoService,
+          useValue: {} as Partial<LtoService>
+        },
+        {
+          provide: Router,
+          useValue: {}
         }
       ]
     }).compileComponents();
 
     localAccounts = TestBed.get(LocalAccountsService);
     authService = TestBed.get(AuthService);
+    ltoService = TestBed.get(LtoService);
 
     fixture = TestBed.createComponent(ImportAccountComponent);
     component = fixture.componentInstance;
@@ -37,5 +53,6 @@ fdescribe('auth/ImportAccountComponent', () => {
 
   it('should disable Login button if no local accounts presented', () => {
     const loginLink = fixture.debugElement.query(By.css('.login-link'));
+    expect(loginLink.attributes.disabled).toBe('true');
   });
 });

--- a/apps/wallet/src/app/auth/import-account/import-account.component.ts
+++ b/apps/wallet/src/app/auth/import-account/import-account.component.ts
@@ -4,6 +4,8 @@ import { Router } from '@angular/router';
 import { LocalAccountsService, AuthService } from '../../core';
 import { MatSnackBar } from '@angular/material';
 import { LtoService } from '@lto/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'wallet-import-account',
@@ -12,6 +14,7 @@ import { LtoService } from '@lto/core';
 })
 export class ImportAccountComponent implements OnInit {
   importForm!: FormGroup;
+  loginDisabled$!: Observable<boolean>;
 
   constructor(
     private _localAccountsService: LocalAccountsService,
@@ -27,6 +30,10 @@ export class ImportAccountComponent implements OnInit {
       accountName: new FormControl('', [Validators.required]),
       password: new FormControl('', [Validators.required])
     });
+
+    this.loginDisabled$ = this._localAccountsService.availableAccounts$.pipe(
+      map(accounts => accounts.length === 0)
+    );
   }
 
   importAccountAndRedirect() {

--- a/apps/wallet/src/app/auth/login.guard.spec.ts
+++ b/apps/wallet/src/app/auth/login.guard.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { LocalAccountsService, LocalUserAccount } from '../core';
+import { LoginGuard } from './login.guard';
+import { of } from 'rxjs';
+
+describe('auth/LoginGuard', () => {
+  let guard: LoginGuard;
+  let localAccounts: LocalAccountsService;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        LoginGuard,
+        {
+          provide: Router,
+          useValue: {
+            navigate: jasmine.createSpy('navigate')
+          } as Partial<Router>
+        },
+        { provide: LocalAccountsService, useValue: {} as Partial<LocalAccountsService> }
+      ]
+    });
+
+    guard = TestBed.get(LoginGuard);
+    router = TestBed.get(Router);
+    localAccounts = TestBed.get(LocalAccountsService);
+  });
+
+  describe('#canActivate', () => {
+    it('should not allow to activate if no local accounts', async () => {
+      localAccounts.availableAccounts$ = of([]);
+      const canActivate = await guard.canActivate().toPromise();
+      expect(canActivate).toBe(false);
+      expect(router.navigate).toHaveBeenCalledWith(['/', 'auth', 'create']);
+    });
+
+    it('should allow to activate if local accounts exist', async () => {
+      localAccounts.availableAccounts$ = of([
+        LocalUserAccount.fromJSON({
+          accountName: 'TestAccount'
+        })
+      ]);
+      const canActivate = await guard.canActivate().toPromise();
+      expect(canActivate).toBe(true);
+    });
+  });
+});

--- a/apps/wallet/src/app/auth/login.guard.ts
+++ b/apps/wallet/src/app/auth/login.guard.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { LocalAccountsService } from '../core';
+import { of } from 'rxjs';
+import { take, map, tap } from 'rxjs/operators';
+
+/**
+ * Redirect to /create if no local accounts
+ */
+@Injectable({ providedIn: 'root' })
+export class LoginGuard implements CanActivate {
+  constructor(private _localAccounts: LocalAccountsService, private _router: Router) {}
+
+  canActivate() {
+    return this._localAccounts.availableAccounts$.pipe(
+      take(1),
+      map(accounts => accounts.length !== 0),
+      tap(haveAccounts => {
+        if (!haveAccounts) {
+          this._router.navigate(['/', 'auth', 'create']);
+        }
+      })
+    );
+  }
+}

--- a/apps/wallet/src/app/core/guards/auth.guard.spec.ts
+++ b/apps/wallet/src/app/core/guards/auth.guard.spec.ts
@@ -1,10 +1,10 @@
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { AuthService } from '../services';
 import { AuthGuard } from './auth.guard';
 import { of } from 'rxjs';
 
-describe('AuthGuard', () => {
+describe('core/AuthGuard', () => {
   let authMock: Partial<AuthService>;
   let routerMock: Partial<Router>;
   let guard: AuthGuard;


### PR DESCRIPTION
* Redirect to "Create account" if a user tries to open the "login" page and no local accounts found
* Disable "Login" link on "Create account" page if no local accounts found
* Disable "Login" link on "Import account" page if no local accounts found

Closes #39 