### PR TITLE
remove transaction type from statistic request

### DIFF
--- a/apps/explorer/src/app/dashboard/components/statistics/statistics.component.html
+++ b/apps/explorer/src/app/dashboard/components/statistics/statistics.component.html
@@ -1,5 +1,5 @@
 <mat-card>
-  <mat-card-title>Transactions statistics</mat-card-title>
+  <mat-card-title>Transaction statistics</mat-card-title>
   <mat-card-content>
     <div class="chart-container" [ngSuspense]="chartData$">
       <div

--- a/apps/explorer/src/app/dashboard/components/statistics/statistics.component.ts
+++ b/apps/explorer/src/app/dashboard/components/statistics/statistics.component.ts
@@ -57,7 +57,7 @@ export class StatisticsComponent {
     const endDate = new Date();
     const startDate = new Date();
     if (granularity === Granularity.Last7Days) {
-      endDate.setDate(now.getDate() - 1);
+      endDate.setDate(now.getDate() - 2);
       startDate.setDate(endDate.getDate() - 7);
     } else {
       endDate.setHours(now.getHours() - 2);

--- a/apps/explorer/src/app/dashboard/components/statistics/statistics.component.ts
+++ b/apps/explorer/src/app/dashboard/components/statistics/statistics.component.ts
@@ -57,7 +57,7 @@ export class StatisticsComponent {
     const endDate = new Date();
     const startDate = new Date();
     if (granularity === Granularity.Last7Days) {
-      endDate.setDate(now.getDate() - 2);
+      endDate.setDate(now.getDate() - 1);
       startDate.setDate(endDate.getDate() - 7);
     } else {
       endDate.setHours(now.getHours() - 2);

--- a/libs/core/src/lib/services/statistics.service.ts
+++ b/libs/core/src/lib/services/statistics.service.ts
@@ -19,7 +19,6 @@ export class StatisticsServiceImpl {
 
   transactions(config: TransactionsStatsConfig) {
     const requestConfig = {
-      type: TransactionType.ANCHOR,
       granularity: 'day',
       ...config
     };


### PR DESCRIPTION
* Remove limitation for `anchor` statistics only. Now we pull statistics for all transactions